### PR TITLE
Fix for long text actionbar handling (fixes #5).

### DIFF
--- a/app/src/main/res/layout/activity_text_editor.xml
+++ b/app/src/main/res/layout/activity_text_editor.xml
@@ -3,25 +3,33 @@
                                                    xmlns:app="http://schemas.android.com/apk/res-auto"
                                                    android:layout_width="match_parent"
                                                    android:layout_height="match_parent">
-    <EditText
+
+    <ScrollView
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:inputType="textMultiLine"
-            android:gravity="start|top"
-            android:ems="10"
-            android:id="@+id/editText"
+            android:id="@+id/bodyScrollView"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginEnd="8dp"
             app:layout_constraintBottom_toBottomOf="parent" android:layout_marginBottom="8dp"
             app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp" app:layout_constraintTop_toBottomOf="@+id/titleEditText"/>
+            android:layout_marginTop="8dp" app:layout_constraintTop_toBottomOf="@+id/titleEditText"
+            android:fillViewport="true">
+        <EditText
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:inputType="textMultiLine"
+                android:gravity="start|top"
+                android:ems="10"
+                android:id="@+id/editText"
+                android:layout_marginEnd="8dp"
+                />
+    </ScrollView>
     <TextView
             android:text="@string/file_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/textView" app:layout_constraintStart_toStartOf="parent"
             android:layout_marginTop="8dp" app:layout_constraintTop_toTopOf="parent" android:layout_marginBottom="8dp"
-            app:layout_constraintBottom_toTopOf="@+id/editText" app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintBottom_toTopOf="@+id/bodyScrollView" app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintEnd_toStartOf="@+id/titleEditText"
             android:layout_marginStart="8dp" android:layout_marginEnd="8dp"/>
     <EditText
@@ -35,6 +43,6 @@
             android:layout_marginEnd="8dp" app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="8dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
-            android:layout_marginBottom="8dp" app:layout_constraintBottom_toTopOf="@+id/editText"/>
+            android:layout_marginBottom="8dp" app:layout_constraintBottom_toTopOf="@+id/bodyScrollView"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
EditText scroll feature is buggy and it's better use ScrollView instead.
When EditText is long and scrollbar appear, select whole text area cause action bar to hide.
It prevent select copy and other menu from action bar.

This commit enclose EditText with ScrollView.
From constraintsLayout point of view, ScrollView behave the same as previous EditText.