### PR TITLE
Exclude folder (fixes #17)

### DIFF
--- a/app/src/main/java/com/github/harukawa/drivetext/MainActivity.kt
+++ b/app/src/main/java/com/github/harukawa/drivetext/MainActivity.kt
@@ -206,7 +206,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         launch(Dispatchers.Default) {
             val result = googleDriveService.files().list().apply {
                 spaces = "drive"
-                q = "trashed=false"
+                q = "trashed=false and mimeType!='application/vnd.google-apps.folder'"
                 fields = "nextPageToken, files(id, name, modifiedTime, parents)"
                 this.pageToken = pageToken
             }.execute()


### PR DESCRIPTION
対象フォルダの中にフォルダがあっても無視するようにする修正です。
archiveフォルダを作っていらないものを入れていきたい。