### PR TITLE
Fix file default extension(fixes #21)

### DIFF
--- a/app/src/main/java/com/github/harukawa/drivetext/TextEditorActivity.kt
+++ b/app/src/main/java/com/github/harukawa/drivetext/TextEditorActivity.kt
@@ -213,13 +213,8 @@ class TextEditorActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         isSave = true
         listTextView.text = text
 
-        if(localFile.fileId != "") {
-            titleText.setText(localFile.name)
-        } else {
-            val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-            val EXTENSION = prefs.getString("extension", ".txt")
-            titleText.setText(localFile.name+EXTENSION)
-        }
+        titleText.setText(localFile.name)
+        
         input.close()
     }
 

--- a/app/src/main/java/com/github/harukawa/drivetext/TextEditorActivity.kt
+++ b/app/src/main/java/com/github/harukawa/drivetext/TextEditorActivity.kt
@@ -65,8 +65,7 @@ class TextEditorActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_text_editor)
 
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        val EXTENSION = prefs.getString("extension", ".txt")
+        val EXTENSION = ".txt"
 
         dbId = intent.getLongExtra("DB_ID",-1L)
         if(dbId != -1L) {
@@ -214,7 +213,7 @@ class TextEditorActivity : AppCompatActivity(), CoroutineScope by MainScope() {
         listTextView.text = text
 
         titleText.setText(localFile.name)
-        
+
         input.close()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,8 +3,6 @@
     <string name="file_name">ファイル名</string>
     <string name="parent_drive_file">ドライブファイルID</string>
     <string name="file_id"></string>
-    <string name="default_extension">.txt</string>
-    <string name="title_extension">ファイル拡張子</string>
     <string name="yes">はい</string>
     <string name="no">いいえ</string>
     <string name="dialog_delete_message">全てのデータを削除しますか?</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -6,8 +6,4 @@
         app:key="drive_parent_path"
         app:defaultValue="@string/file_id"
         app:title="@string/parent_drive_file"/>
-<EditTextPreference
-        app:key="extension"
-        app:defaultValue="@string/default_extension"
-        app:title="@string/title_extension"/>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
アップロードしていないファイルを開くと、ファイル拡張子が勝手に追加されてしまうバグを修正。
デフォルトファイル拡張子の設定は必要ないので削除しました。