### PR TITLE
Fix indicator not shown in L (fixes #41)

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,6 +20,7 @@
         <ProgressBar
                 android:id="@+id/progressBar"
                 android:indeterminateTint="@color/colorAccent"
+                android:indeterminateTintMode="src_atop"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:visibility="gone" />


### PR DESCRIPTION
手元のギャラノ3でインジケータが出なかったバグを直す。
良く理由は分かってないですが、、、